### PR TITLE
Release/1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,171 +39,189 @@ Requires complex values (objects, arrays, functions, and JSX) that get passed pr
 Options:
 
 - `{strict: true}`: Fails even in cases where it is difficult to determine if the value in question is a primitive (string or number) or a complex value (object, array, etc.);
-- `{checkHookReturnObject: true}`: Will require Object Expressions passed in return statements (e.g. `return {someFunc}`) to also be memoised (e.g. `return useMemo(() => ({someFunc}), [someFunc])`); **Disabled** by default.
+
+- `{checkHookReturnObject: true}`: Will require Object Expressions passed in return statements (e.g. `return {someFunc}`) to also be memoised (e.g. `return useMemo(() => ({someFunc}), [someFunc])`); **Disabled** by default;
+
+- `{checkHookCalls: true}`: Will require objects/data passed to a non-native/Custom hook to be memoized (e.g. in this code `const data = useParse(unparsedData)` it will check `unparsedData` for memo status), this check can be ignored by a hook/name basis, check next item for details; **Enabled** by default;
+
+- `{ignoredHookCallsNames: Record<string, boolean>}`: You can add specific hooks names here, individually disabling or enabling them to be checked when used, e.g. if you have a custom hook named `useX` and it should be called with unmemoized parameters you can set `{ ignoredHookCallsNames: { useX: false } }` and then have somethning like `const data = {}; const x = useX(data);` not generate any errors.
 
 ### Function Components
 #### **Incorrect**
 ```JavaScript
-function Component() {
+  function Component() {
 
-  const [data, setData] = useState([]);
-  
-  
-  // This will be redeclared each render
-  function renderItem({ item }) {
-    return (<Text>item.name</Text>);
+    const [data, setData] = useState([]);
+    
+    
+    // This will be redeclared each render
+    function renderItem({ item }) {
+      return (<Text>item.name</Text>);
+    }
+
+    // Data isn't redeclared each ender but `[]` is
+    return (<FlatList renderItem={renderItem} data={data ?? []} />);
   }
-
-  // Data isn't redeclared each ender but `[]` is
-  return (<FlatList renderItem={renderItem} data={data ?? []} />);
-}
 ```
 #### **Correct**
 ```JavaScript
-// Has no dynamic dependencies therefore should be static, will be declared only once.
-function renderItem({ item }) {
-  return <Text>item.name</Text>;
-}
+  // Has no dynamic dependencies therefore should be static, will be declared only once.
+  function renderItem({ item }) {
+    return <Text>item.name</Text>;
+  }
 
-const EMPTY_ARRAY = [];
+  const EMPTY_ARRAY = [];
 
-function Component() {
+  function Component() {
 
-  const [data, setData] = useState(EMPTY_ARRAY);
-  
-  // Will only render again if data changes
-  return (<FlatList renderItem={renderItem} data={data ?? EMPTY_ARRAY} />);
-}
+    const [data, setData] = useState(EMPTY_ARRAY);
+    
+    // Will only render again if data changes
+    return (<FlatList renderItem={renderItem} data={data ?? EMPTY_ARRAY} />);
+  }
 ```
 ### Class Components
 #### **Incorrect**
 ```JavaScript
-class Component() {
+  class Component() {
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      data: undefined,
-      propDrivenData: props.,
-    };
-  }
-  
-  
-  // This will NOT be redeclared each render
-  getItemName(item) {
-    return item.name;
-  }
-
-  render() {
-    // This function will be redeclared each render
-    function renderItem({ item }) {
-      return (<Text>{this.getItemName(item)}</Text>);
+    constructor(props) {
+      super(props);
+      this.state = {
+        data: undefined,
+        propDrivenData: props.,
+      };
+    }
+    
+    
+    // This will NOT be redeclared each render
+    getItemName(item) {
+      return item.name;
     }
 
-    // Data isn't redeclared each ender but [] is
-    // Extradata has a exponential complexity (will iterate the entire array for each render, could render once or several times in a second)
-    // Outcome will be that any new render on this component will cause the entire FlatList to render again, including children components, even if the data hasn't changed.
-    return (<FlatList
-      renderItem={renderItem}
-      data={data ?? []} 
-      extraData={dataArray.filter(id => !!id)}
-    />);
+    render() {
+      // This function will be redeclared each render
+      function renderItem({ item }) {
+        return (<Text>{this.getItemName(item)}</Text>);
+      }
+
+      // Data isn't redeclared each ender but [] is
+      // Extradata has a exponential complexity (will iterate the entire array for each render, could render once or several times in a second)
+      // Outcome will be that any new render on this component will cause the entire FlatList to render again, including children components, even if the data hasn't changed.
+      return (<FlatList
+        renderItem={renderItem}
+        data={data ?? []} 
+        extraData={dataArray.filter(id => !!id)}
+      />);
+    }
   }
-}
 ```
 In the previous example there are two issues, a function and a object that will be dynamically redeclared each time the component renders, which will cause FlatList to keep re-rendering even when the input data hasn't changed.
 
 #### **Correct**
 ```JavaScript
 
-// Static therefore is only declared once
-const EMPTY_ARRAY = [];
+  // Static therefore is only declared once
+  const EMPTY_ARRAY = [];
 
-class Component() {
-  constructor(props) {
-    super(props);
-    this.state = {
-      data: undefined,
-      propDrivenData: props.dataArray.filter(id => !!id),
-    };
-  }
-  
-  // Properly regenerate state driven data only when props change instead of during each render
-  static getDerivedStateFromProps(props) {
-    if (props.propDrivenData !== this.props.propDrivenData) {
-      return {
+  class Component() {
+    constructor(props) {
+      super(props);
+      this.state = {
+        data: undefined,
         propDrivenData: props.dataArray.filter(id => !!id),
       };
     }
-    return null;
-  }
+    
+    // Properly regenerate state driven data only when props change instead of during each render
+    static getDerivedStateFromProps(props) {
+      if (props.propDrivenData !== this.props.propDrivenData) {
+        return {
+          propDrivenData: props.dataArray.filter(id => !!id),
+        };
+      }
+      return null;
+    }
 
-  // Will be declared only once.
-  getItemName({item}) {
-    const { data } = this.state;
-    const dataLength = data ? data.length : 0;
-    return (<Text>{item.name} {dataLength}</Text>);
-  }
+    // Will be declared only once.
+    getItemName({item}) {
+      const { data } = this.state;
+      const dataLength = data ? data.length : 0;
+      return (<Text>{item.name} {dataLength}</Text>);
+    }
 
-  render() {
-    const { data } = this.state;
-    // Will only cause a new render if data changes
-    return (<FlatList renderItem={this.renderItem} data={data ?? EMPTY_ARRAY} />);
+    render() {
+      const { data } = this.state;
+      // Will only cause a new render if data changes
+      return (<FlatList renderItem={this.renderItem} data={data ?? EMPTY_ARRAY} />);
+    }
   }
-}
 ```
 #### **Correct**
 ```JavaScript
-const EMPTY_ARRAY = [];
+  const EMPTY_ARRAY = [];
 
-function Component() {
-  const [data, setData] = useState(EMPTY_ARRAY);
-  const [isEditing, setIsEditing] = useState(false);
+  function Component() {
+    const [data, setData] = useState(EMPTY_ARRAY);
+    const [isEditing, setIsEditing] = useState(false);
 
-  // Has dynamic dependencies but will only be re-declared when isEditing or the input data changes
-  const renderItem = useCallback(({ item }) => {
-    return (<Text>{isEditing ? 'item.name' : 'Editing'}</Text>);
-  }, [isEditing]);
+    // Has dynamic dependencies but will only be re-declared when isEditing or the input data changes
+    const renderItem = useCallback(({ item }) => {
+      return (<Text>{isEditing ? 'item.name' : 'Editing'}</Text>);
+    }, [isEditing]);
 
-  return (<FlatList renderItem={renderItem} data={data ?? EMPTY_ARRAY} />);
-}
+    return (<FlatList renderItem={renderItem} data={data ?? EMPTY_ARRAY} />);
+  }
 ```
 ### Hooks
 Hooks return statements follow the same motto, they can and usually are used inside other hooks.
 
 #### **Incorrect**
 ```JavaScript
-function useData() {
+  function useData() {
 
-  let otherData = {};
-  function getData() {
-    // Doing something
+    let otherData = {};
+    function getData() {}
+    
+    return { getData, otherData};
   }
-  
-  
-  return { getData, otherData};
-}
 ```
 #### **Incorrect** (checkHookReturnObject: true)
 ```JavaScript
-  function getData() {
-    // Doing something
+  function getData() {}
+
+  function useData() {
+    
+    return { getData };
   }
-function useData() {
-  
-  return { getData };
-}
+```
+
+#### **Incorrect** Calling a custom hook
+```JavaScript
+  function doSomething() {}
+
+  function useStateManagement(someFlag) {
+    useEffect(() => {
+      doSomething(someFlag);
+    }, [someFlag]);
+  }
+
+  function useData() {
+    const someFlag = {};
+    // Some flag is memoized, so not unwanted side effects are generated in the other hook
+    const data = useStateManagement(someFlag);
+  }
 ```
 
 #### **Correct**
 ```JavaScript
   const otherData = {}; // Or declare inside hook with useMemo
 
-function useData() {
-  const getData = useCallback(() => { // Or declare statically
-  }, []);
-  return {getData, otherData};
-}
+  function useData() {
+    const getData = useCallback(() => { // Or declare statically
+    }, []);
+    return {getData, otherData};
+  }
 ```
 
 #### **Correct** (checkHookReturnObject: true)
@@ -211,11 +229,54 @@ function useData() {
   function getData() {
     // Doing something
   }
-function useData() {
-  
-  return useMemo(() => ({ getData }), []);
-}
+  function useData() {
+    
+    return useMemo(() => ({ getData }), []);
+  }
 ```
+#### **Correct** Passing a dependency to a hook
+```JavaScript
+  function getData() {}
+
+  function useData() {
+    
+    return useMemo(() => ({ getData }), []);
+  }
+```
+#### **Correct** Calling a custom hook
+```JavaScript
+  function doSomething() {}
+
+  function useStateManagement(someFlag) {
+    useEffect(() => {
+      doSomething(someFlag);
+    }, [someFlag]);
+  }
+
+  function useData() {
+    const someFlag = useMemo(() => ({}), []);
+    // Some flag is memoized, so not unwanted side effects are generated in the other hook
+    const data = useStateManagement(someFlag);
+  }
+```
+#### **"Correct"** Calling a custom hook (checkHookCalls: true) or (ignoredHookCallsNames: { useStateManagement: false })
+```JavaScript
+  function doSomething() {
+  }
+  function useStateManagement(someFlag) {
+    useEffect(() => {
+      doSomething(someFlag);
+    }, [someFlag]);
+  }
+
+  function useData() {
+    const someFlag = useMemo(() => ({}), []);
+    // Some flag is regenerated each render, hence useEffect in "useStateManagement" will execute a new cycle each render
+    // Either way this will not generate a error/warning because of the options passed
+    const data = useStateManagement(someFlag);
+  }
+```
+
 
 
 ## `require-memo`
@@ -225,16 +286,16 @@ May be useful when used with overrides in your eslint config, I do not recommend
 
 ## **Incorrect**
 ```JavaScript
-export default function Component() {
-  return (<Text>This is a component</Text>);
-}
+  export default function Component() {
+    return (<Text>This is a component</Text>);
+  }
 ```
 
 ## **Correct**
 ```JavaScript
-export default memo(function Component() {
-  return (<Text>This is a component</Text>);
-});
+  export default memo(function Component() {
+    return (<Text>This is a component</Text>);
+  });
 ```
 
 ## `require-usememo-children` **Advanced**
@@ -247,23 +308,23 @@ Options:
 
 ## **Incorrect**
 ```JavaScript
-function Component() {
+  function Component() {
 
-  return (<View>
-    <>
-    <OtherComponent />
-    </>
-  </View>);
-}
+    return (<View>
+      <>
+      <OtherComponent />
+      </>
+    </View>);
+  }
 ```
    
 ## **Correct**
 ```JavaScript
-function Component() {
-  const children = useMemo(() => (<OtherComponent />), []);
-  
-  return (<View>
-    {children}
-  </View>);
-}
+  function Component() {
+    const children = useMemo(() => (<OtherComponent />), []);
+    
+    return (<View>
+      {children}
+    </View>);
+  }
 ```

--- a/__tests__/require-usecallback.ts
+++ b/__tests__/require-usecallback.ts
@@ -92,6 +92,12 @@ ruleTester.run("useCallback", rule as Rule.RuleModule , {
         const myFn = lodash.memoize(() => []);
         return <Child prop={myFn} />;
       }`,
+    },{
+      code:`const Component = () => {
+        const myFn1 = () => [];
+        const myFn2 = React.useCallback(() => myFn1, [myFn1]);
+        return <Child prop={myFn2} />;
+      }`,
     },
   ],
   invalid: [
@@ -180,11 +186,10 @@ ruleTester.run("useCallback", rule as Rule.RuleModule , {
     },
     {
       code: `const Component = () => {
-        const myFn1 = () => [];
-        const myFn2 = React.useCallback(() => myFn1, [myFn1]);
-        return <Child prop={myFn2} />;
+        const myFn = () => [];
+        return <Child prop={myFn} />;
       }`,
-      errors: [{ messageId: "function-usecallback-deps" }],
+      errors: [{ messageId: "function-usecallback-props" }],
     },
   ],
 });

--- a/__tests__/require-usememo.ts
+++ b/__tests__/require-usememo.ts
@@ -18,7 +18,7 @@ ruleTester.run("useMemo", rule as Rule.RuleModule, {
     },
     {
       code: `const Component = () => {
-      const myArray = useMemo(() => [], []);
+      const myArray = React.useMemo(() => [], []);
       return <Child prop={myArray} />;
     }`,
     },
@@ -175,6 +175,55 @@ ruleTester.run("useMemo", rule as Rule.RuleModule, {
         return myString;
       }`,
     },
+    {
+      code: `function useTesty() {
+        const myBool = React.useMemo(() => !!{}, []);
+        return myBool;
+      }`,
+    },
+    {
+      code: `function useTesty() {
+        const x = {};
+        const myBool = React.useMemo(() => x, [x]);
+        return myBool;
+      }`,
+    },
+    {
+        code: `
+        function useTesty() {
+          const x = {};
+          return useData(x);
+        }`,
+        options: [{ checkHookReturnObject: true, checkHookCalls: false }],
+      },
+    {
+        code: `
+        function useTesty() {
+          const x = {};
+          return useData(x);
+        }`,
+        options: [{ checkHookReturnObject: true, ignoredHookCallsNames: {"useData": true} }],
+      },
+    {
+      code: `const Component = () => {
+        const myArray1 = [];
+        const myArray2 = React.useMemo(() => myArray1, [myArray1]);
+        return <Child prop={myArray2} />;
+      }`,
+    },
+    {
+      code: `function useTest() {
+        const y: boolean | undefined = false;
+        const x = useMemo(() => x, [y]);
+        return {x};
+      }`,
+    },
+    {
+      code: `function useTest({data}: {data: boolean | undefined}) {
+        const x = useMemo(() => !data, [data]);
+        return {x};
+      }`,
+    },
   ],
   invalid: [
     {
@@ -217,7 +266,7 @@ ruleTester.run("useMemo", rule as Rule.RuleModule, {
     },
     {
       code: `const Component = () => {
-        let myObject = useMemo({});
+        let myObject = React.useMemo(() => ({}), []);
         myObject = {a: 'b'};
         return <Child prop={myObject} />;
       }`,
@@ -279,14 +328,6 @@ ruleTester.run("useMemo", rule as Rule.RuleModule, {
     },
     {
       code: `const Component = () => {
-        const myArray1 = [];
-        const myArray2 = React.useMemo(() => myArray1, [myArray1]);
-        return <Child prop={myArray2} />;
-      }`,
-      errors: [{ messageId: "array-usememo-deps" }],
-    },
-    {
-      code: `const Component = () => {
         const myComplexString = css\`color: red;\`;
         return <Child prop={myComplexString} />;
       }`,
@@ -342,6 +383,31 @@ ruleTester.run("useMemo", rule as Rule.RuleModule, {
       code: `function useTest() {
         function myFunction(){ };
         return myFunction;
+      }`,
+      errors: [{ messageId: "function-usecallback-hook" }],
+    },
+    {
+      code: `
+      function useTesty() {
+        const x = {};
+        return useData(x);
+      }`,
+      options: [{ checkHookReturnObject: true, ignoredHookCallsNames: {"useOtherHook": true} }],
+      errors: [{ messageId: "object-usememo-deps" }],
+    },
+    {
+      code: `function useTest() {
+        let y = '';
+        const x = useMemo(() => '', []);
+        return {x, y};
+      }`,
+      errors: [{ messageId: "usememo-const" }],
+    },
+    {
+      code: `const useTest = () => {
+        const x: boolean | undefined = false;
+        function y() {}
+        return {x, y};
       }`,
       errors: [{ messageId: "function-usecallback-hook" }],
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arthurgeron/eslint-plugin-react-usememo",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "",
   "main": "dist/index.js",
   "author": "Stefano J. Attardi <github@attardi.org> & Arthur Geron <github@arthurgeron.org",

--- a/src/common.ts
+++ b/src/common.ts
@@ -18,6 +18,7 @@ export enum MemoStatus {
   UnmemoizedFunctionCall,
   UnmemoizedJSX,
   UnmemoizedOther,
+  UnsafeLet
 }
 
 export function isComponentName(name: string) {
@@ -59,11 +60,7 @@ function getIdentifierMemoStatus(
   if (node.type === "FunctionDeclaration") return MemoStatus.UnmemoizedFunction;
   if (node.type !== "VariableDeclarator") return MemoStatus.Memoized;
   if (node.parent.kind === "let") {
-    context.report({ node, messageId: "usememo-const" });
-    if (!node.init) {
-      // Rely on usememo-const reported error to fail this identifier
-      return MemoStatus.Memoized;
-    }
+    return MemoStatus.UnsafeLet;
   }
   return getExpressionMemoStatus(context, node.init);
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,9 +2,9 @@ export const MessagesRequireUseMemo = {
   "object-usememo-props":
     "Object literal should be wrapped in useMemo() or be static when used as a prop",
   "object-class-memo-props":
-    "Object literal should com from state or be static when used as a prop",
+    "Object literal should come from state or be static when used as a prop",
   "object-usememo-hook":
-    "Object literal should com from state or be static when returned from a hook",
+    "Object literal should come from state or be static when returned from a hook",
   "object-usememo-deps":
     "Object literal should be wrapped in useMemo() or be static when used as a hook dependency",
   "array-usememo-props":

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,7 +46,7 @@ export const MessagesRequireUseMemo = {
   "unknown-usememo-deps":
     "Unknown value may need to be wrapped in useMemo() when used as a hook dependency",
   "usememo-const":
-    "useMemo/useCallback return value should be assigned to a const to prevent reassignment",
+    "useMemo/useCallback return value should be assigned to a `const` to prevent reassignment",
 };
 
 export const MessagesRequireUseMemoChildren = {
@@ -63,6 +63,6 @@ export const MessagesRequireUseMemoChildren = {
   "unknown-usememo-children":
     "Unknown value may need to be wrapped in React.useMemo() when used as children",
   "usememo-const":
-    "useMemo/useCallback return value should be assigned to a const to prevent reassignment",
+    "useMemo/useCallback return value should be assigned to a `const` to prevent reassignment",
 };
 

--- a/src/require-usememo-children.ts
+++ b/src/require-usememo-children.ts
@@ -4,9 +4,9 @@ import { TSESTree } from "@typescript-eslint/types";
 import {
   getExpressionMemoStatus,
   isComplexComponent,
-  MemoStatus,
 } from "./common";
 import { MessagesRequireUseMemoChildren } from "./constants";
+import { MemoStatus } from "src/types";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -45,7 +45,8 @@ const rule: Rule.RuleModule = {
           if (child.type === "JSXExpressionContainer") {
             const { expression } = child;
             if (expression.type !== "JSXEmptyExpression") {
-              switch (getExpressionMemoStatus(context, expression)) {
+              const statusData = getExpressionMemoStatus(context, expression);
+              switch (statusData.status) {
                 case MemoStatus.UnmemoizedObject:
                   report(node, "object-usememo-children");
                   break;

--- a/src/require-usememo/constants.ts
+++ b/src/require-usememo/constants.ts
@@ -1,8 +1,5 @@
+import { MemoStatus } from 'src/types';
 import type { ExpressionData} from './types';
-import {
-  MemoStatus,
-} from "../common";
-
 
 export const ValidExpressions: Record<string, boolean> = {
   'ArrowFunctionExpression': true,

--- a/src/require-usememo/constants.ts
+++ b/src/require-usememo/constants.ts
@@ -21,6 +21,7 @@ export const jsxEmptyExpressionClassData: ExpressionData = {
   [MemoStatus.UnmemoizedFunction.toString()]: 'instance-class-memo-props',
   [MemoStatus.UnmemoizedFunctionCall.toString()]: "unknown-class-memo-props",
   [MemoStatus.UnmemoizedOther.toString()]: "unknown-class-memo-props",
+  [MemoStatus.UnsafeLet.toString()]: "usememo-const",
 }
 
 export const jsxEmptyExpressionData: ExpressionData = {
@@ -31,6 +32,7 @@ export const jsxEmptyExpressionData: ExpressionData = {
   [MemoStatus.UnmemoizedFunctionCall.toString()]: "unknown-usememo-props",
   [MemoStatus.UnmemoizedOther.toString()]: "unknown-usememo-props",
   [MemoStatus.UnmemoizedJSX.toString()]: "jsx-usememo-props",
+  [MemoStatus.UnsafeLet.toString()]: "usememo-const",
 }
 
 export const hookReturnExpressionData: ExpressionData = {
@@ -41,6 +43,7 @@ export const hookReturnExpressionData: ExpressionData = {
   [MemoStatus.UnmemoizedFunctionCall.toString()]: "unknown-usememo-hook",
   [MemoStatus.UnmemoizedOther.toString()]: "unknown-usememo-hook",
   [MemoStatus.UnmemoizedJSX.toString()]: "jsx-usememo-hook",
+  [MemoStatus.UnsafeLet.toString()]: "usememo-const",
 }
 
 export const callExpressionData: ExpressionData = {
@@ -51,4 +54,27 @@ export const callExpressionData: ExpressionData = {
   [MemoStatus.UnmemoizedFunctionCall.toString()]: "unknown-usememo-deps",
   [MemoStatus.UnmemoizedOther.toString()]: "unknown-usememo-deps",
   [MemoStatus.UnmemoizedJSX.toString()]: "jsx-usememo-deps",
+  [MemoStatus.UnsafeLet.toString()]: "usememo-const",
+}
+
+export const defaultReactHookNames: Record<string, boolean | undefined> = {
+  "useContext": true,
+  "useState": true,
+  "useReducer": true,
+  "useRef": true,
+  "useLayoutEffect": true,
+  "useEffect": true,
+  "useImperativeHandle": true,
+  "useCallback": true,
+  "useMemo": true,
+  "useDebugValue": true,
+  "useDeferredValue": true,
+  "useTransition": true,
+  "useId": true,
+  "useInsertionEffect": true,
+  "useSyncExternalStore": true,
+  "useQuery": true,
+  "useMutation": true,
+  "useQueryClient": true,
+  "useInfiniteQuery": true,
 }

--- a/src/require-usememo/index.ts
+++ b/src/require-usememo/index.ts
@@ -65,7 +65,10 @@ const rule: Rule.RuleModule  = {
       },
 
       ReturnStatement(node) {
-        if (node.parent.parent.type === 'FunctionDeclaration' && getIsHook(node.parent.parent.id as TSESTree.Identifier) && node.argument) {
+        const functionDeclarationNode = node.parent?.parent?.type === 'FunctionDeclaration' && node?.parent?.parent?.id;
+        const anonFuncVariableDeclarationNode = node.parent?.parent?.type === 'ArrowFunctionExpression' && node?.parent?.parent?.parent?.type === 'VariableDeclarator' && node?.parent?.parent?.parent?.id;
+        const validNode = functionDeclarationNode || anonFuncVariableDeclarationNode;
+        if (validNode && getIsHook(validNode as TSESTree.Identifier) && node.argument) {
             if (node.argument.type === 'ObjectExpression' ) {
               if (context.options?.[0]?.checkHookReturnObject) {
                 context.report({ node, messageId: "object-usememo-hook" });

--- a/src/require-usememo/types.ts
+++ b/src/require-usememo/types.ts
@@ -5,5 +5,5 @@ import { MessagesRequireUseMemo} from '../constants';
 export type ExpressionTypes = TSESTree.ArrowFunctionExpression | TSESTree.JSXExpressionContainer | TSESTree.Expression | TSESTree.ObjectExpression | TSESTree.ArrayExpression | TSESTree.Identifier | TSESTree.LogicalExpression | TSESTree.JSXEmptyExpression;
 
 export type NodeType = TSESTree.MethodDefinitionComputedName;
-export type Node = TSESTree.CallExpression & Rule.NodeParentExtension
+export type ESNode = TSESTree.CallExpression & Rule.NodeParentExtension
 export type ExpressionData = Record<string | number | symbol, keyof typeof MessagesRequireUseMemo>;

--- a/src/require-usememo/utils.ts
+++ b/src/require-usememo/utils.ts
@@ -4,7 +4,14 @@ import { MessagesRequireUseMemo } from '../constants';
 import {
   MemoStatus,
 } from "../common";
-import { ExpressionData } from "./types";
+import type { ESNode, ExpressionData } from "./types";
+
+
+export function shouldIgnoreNode(node: ESNode, ignoredNames: Record<string,boolean | undefined> ) {
+  return !!ignoredNames[(node as TSESTree.Node as TSESTree.Identifier)?.name]
+          || !!ignoredNames[(node.callee as TSESTree.Identifier).name]
+          || !!ignoredNames[((node?.callee as TSESTree.MemberExpression)?.property as TSESTree.Identifier)?.name]
+}
 
 export function checkForErrors<T,Y extends Rule.NodeParentExtension | TSESTree.MethodDefinitionComputedName>(data: ExpressionData, expressionType: MemoStatus, context: Rule.RuleContext, node: Y | undefined, report: (node: Y, error: keyof typeof MessagesRequireUseMemo) => void) {
   const errorName = data?.[expressionType.toString()];

--- a/src/require-usememo/utils.ts
+++ b/src/require-usememo/utils.ts
@@ -1,10 +1,8 @@
 import { Rule } from "eslint";
 import { TSESTree } from "@typescript-eslint/types";
 import { MessagesRequireUseMemo } from '../constants';
-import {
-  MemoStatus,
-} from "../common";
 import type { ESNode, ExpressionData } from "./types";
+import { MemoStatusToReport } from "src/types";
 
 
 export function shouldIgnoreNode(node: ESNode, ignoredNames: Record<string,boolean | undefined> ) {
@@ -13,12 +11,12 @@ export function shouldIgnoreNode(node: ESNode, ignoredNames: Record<string,boole
           || !!ignoredNames[((node?.callee as TSESTree.MemberExpression)?.property as TSESTree.Identifier)?.name]
 }
 
-export function checkForErrors<T,Y extends Rule.NodeParentExtension | TSESTree.MethodDefinitionComputedName>(data: ExpressionData, expressionType: MemoStatus, context: Rule.RuleContext, node: Y | undefined, report: (node: Y, error: keyof typeof MessagesRequireUseMemo) => void) {
-  const errorName = data?.[expressionType.toString()];
+export function checkForErrors<T,Y extends Rule.NodeParentExtension | TSESTree.MethodDefinitionComputedName>(data: ExpressionData, statusData: MemoStatusToReport, context: Rule.RuleContext, node: Y | undefined, report: (node: Y, error: keyof typeof MessagesRequireUseMemo) => void) {
+  const errorName = data?.[statusData.status.toString()];
   if (errorName) {
     const strict = errorName.includes('unknown');
     if (!strict || (strict && context.options?.[0]?.strict)) {
-      report(node as Y, errorName);
+      report((statusData.node ?? node) as Y, errorName);
     }
 
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,19 @@
+import { Rule } from "eslint";
+import { TSESTree } from "@typescript-eslint/types";
+
+export type MemoStatusToReport = {
+  node?: Rule.RuleContext | TSESTree.Node,
+  status: MemoStatus
+}
+
+export enum MemoStatus {
+  Memoized,
+  UnmemoizedObject,
+  UnmemoizedArray,
+  UnmemoizedNew,
+  UnmemoizedFunction,
+  UnmemoizedFunctionCall,
+  UnmemoizedJSX,
+  UnmemoizedOther,
+  UnsafeLet
+}


### PR DESCRIPTION
##


## Fixes

- Wrongly checking native hook call arguments for memo
- Fixed bug which would ignore current set of rules/options for hooks declared with `const` instead of `function`
- Added option to disable checkHookCalls
- Disabled equality checks checks on a hook's dependencies array, React already has a rule for doing that
- Add option to exclude specific hook names from checks
- Improved unit tests, fixed typos and other mistakes
- Now errors are more specific about the offending lines, pointing directly to statements/variables
<img width="962" alt="Captura de Tela 2023-03-04 às 16 12 47" src="https://user-images.githubusercontent.com/3487334/222924530-c1897185-9fd5-4fba-9e8d-2f63a8fcad55.png">


