### PR TITLE
fix: assuming a component's props to be unmemoized

### DIFF
--- a/__tests__/require-usememo.ts
+++ b/__tests__/require-usememo.ts
@@ -20,10 +20,29 @@ ruleTester.run("useMemo", rule as Rule.RuleModule, {
       code: `const Component = () => {
       const myArray = React.useMemo(() => [], []);
       return <Child prop={myArray} />;
+      }`
+    },
+    {
+      code: `
+      function Component({data}) {
+      return <Child prop={data} />;
+    }`,
+    },
+    {
+      code: `
+      function x() {}
+      function Component() {
+      return <Child prop={x} />;
     }`,
     },
     {
       code: `const Component = () => {
+      const myArray = React.useMemo(() => new Object(), []);
+      return <Child prop={myArray} />;
+      }`
+    },
+    {
+      code: `function Component() {
       const myArray = React.useMemo(() => new Object(), []);
       return <Child prop={myArray} />;
       }`
@@ -35,6 +54,13 @@ ruleTester.run("useMemo", rule as Rule.RuleModule, {
         render() {
           return <Child prop={myArray} />;
         }
+      }`,
+    },
+    {
+      code: `
+      const myArray = new Object();
+      function Component() {
+        return <Child prop={myArray} />;
       }`,
     },
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arthurgeron/eslint-plugin-react-usememo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "dist/index.js",
   "author": "Stefano J. Attardi <github@attardi.org> & Arthur Geron <github@arthurgeron.org",

--- a/src/require-usememo-children.ts
+++ b/src/require-usememo-children.ts
@@ -46,7 +46,7 @@ const rule: Rule.RuleModule = {
             const { expression } = child;
             if (expression.type !== "JSXEmptyExpression") {
               const statusData = getExpressionMemoStatus(context, expression);
-              switch (statusData.status) {
+              switch (statusData?.status) {
                 case MemoStatus.UnmemoizedObject:
                   report(node, "object-usememo-children");
                   break;

--- a/src/require-usememo/utils.ts
+++ b/src/require-usememo/utils.ts
@@ -12,6 +12,9 @@ export function shouldIgnoreNode(node: ESNode, ignoredNames: Record<string,boole
 }
 
 export function checkForErrors<T,Y extends Rule.NodeParentExtension | TSESTree.MethodDefinitionComputedName>(data: ExpressionData, statusData: MemoStatusToReport, context: Rule.RuleContext, node: Y | undefined, report: (node: Y, error: keyof typeof MessagesRequireUseMemo) => void) {
+  if (!statusData) {
+    return;
+  }
   const errorName = data?.[statusData.status.toString()];
   if (errorName) {
     const strict = errorName.includes('unknown');

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ import { TSESTree } from "@typescript-eslint/types";
 export type MemoStatusToReport = {
   node?: Rule.RuleContext | TSESTree.Node,
   status: MemoStatus
-}
+} | undefined;
 
 export enum MemoStatus {
   Memoized,


### PR DESCRIPTION
Fixes require-usememo assuming a Functional Component or Hook's props to be unmemoized objects/functions.

Before this fix the following code would generate a false error for the prop `onPress`:
```JavaScript
function MyButton({onPress}) {

    return <View onPress={onPress} />;
}
```