### PR TITLE
Fix/1.1.3

### DIFF
--- a/__tests__/require-usememo.ts
+++ b/__tests__/require-usememo.ts
@@ -11,6 +11,19 @@ const ruleTester = new RuleTester({
 ruleTester.run("useMemo", rule as Rule.RuleModule, {
   valid: [
     {
+      code: `function renderItem({
+        field,
+        fieldState,
+      }) {
+        return (
+          <Child 
+          onBlur={field.onBlur}
+          inputRef={field.ref}
+          state={fieldState}
+          />);
+      }`,
+    },
+    {
       code: `const Component = () => {
       const myObject = React.useMemo(() => ({}), []);
       return <Child prop={myObject} />;

--- a/__tests__/require-usememo.ts
+++ b/__tests__/require-usememo.ts
@@ -24,6 +24,23 @@ ruleTester.run("useMemo", rule as Rule.RuleModule, {
       }`,
     },
     {
+      code: `function Component() {
+      let myObject = 'hi';
+      return <Child prop={myObject} />;
+    }`,
+    },
+    {
+      code: `function Component({index = 0}) {
+      const isNotFirst = index > 0;
+      return <Child isNotFirst={isNotFirst} />;
+    }`,
+    },
+    {
+      code: `function Component() {
+        return <Child>{/* Empty Expression Should Not Error :) */}</Child>;
+      }`,
+    },
+    {
       code: `const Component = () => {
       const myObject = React.useMemo(() => ({}), []);
       return <Child prop={myObject} />;
@@ -263,6 +280,13 @@ ruleTester.run("useMemo", rule as Rule.RuleModule, {
         return {x};
       }`,
     },
+    {
+      code: `function useTest() {
+        let y = '';
+        const x = useMemo(() => '', []);
+        return {x, y};
+      }`,
+    },
   ],
   invalid: [
     {
@@ -379,6 +403,13 @@ ruleTester.run("useMemo", rule as Rule.RuleModule, {
         myObject = {};
         return <Child prop={myObject} />;
       }`,
+      errors: [{ messageId: "object-usememo-props" }],
+    },
+    {
+      code: `const Component = () => {
+        let myData = useMemo(() => '', []);
+        return <Child prop={myData} />;
+      }`,
       errors: [{ messageId: "usememo-const" }],
     },
     {
@@ -435,20 +466,19 @@ ruleTester.run("useMemo", rule as Rule.RuleModule, {
       errors: [{ messageId: "object-usememo-deps" }],
     },
     {
-      code: `function useTest() {
-        let y = '';
-        const x = useMemo(() => '', []);
-        return {x, y};
-      }`,
-      errors: [{ messageId: "usememo-const" }],
-    },
-    {
       code: `const useTest = () => {
         const x: boolean | undefined = false;
         function y() {}
         return {x, y};
       }`,
       errors: [{ messageId: "function-usecallback-hook" }],
+    },
+    {
+      code: `function Component() {
+      const component = <OtherChild />;
+      return <Child component={component} />;
+    }`,
+    errors: [{messageId: "jsx-usememo-props"}]
     },
   ],
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
     '<rootDir>/src/*',
     '<rootDir>/src/**/*',
     '!<rootDir>/src/index.{js,ts}',
+    '!<rootDir>/src/**/constants.{js,ts}',
   ],
   cacheDirectory: '.jest-cache',
   coverageThreshold: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arthurgeron/eslint-plugin-react-usememo",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "",
   "main": "dist/index.js",
   "author": "Stefano J. Attardi <github@attardi.org> & Arthur Geron <github@arthurgeron.org",

--- a/src/common.ts
+++ b/src/common.ts
@@ -54,7 +54,8 @@ function getIdentifierMemoStatus(
     return;
   }
 
-  if (node.type === "FunctionDeclaration") return {node: node, status: MemoStatus.UnmemoizedFunction};
+  const isFunctionParameter = node.id.name !== name;
+  if (node.type === "FunctionDeclaration") return {node: node, status: isFunctionParameter ? MemoStatus.Memoized : MemoStatus.UnmemoizedFunction};
   if (node.type !== "VariableDeclarator") return {node: node, status: MemoStatus.Memoized};
   if (node?.parent?.kind === "let") {
     return {node: node.parent, status: MemoStatus.UnsafeLet};
@@ -66,7 +67,8 @@ export function getExpressionMemoStatus(
   context: Rule.RuleContext,
   expression: TSESTree.Expression
 ): MemoStatusToReport {
-  switch (expression.type) {
+  switch (expression?.type) {
+    case undefined:
     case "ObjectExpression":
       return {node: expression, status: MemoStatus.UnmemoizedObject};
     case "ArrayExpression":

--- a/src/common.ts
+++ b/src/common.ts
@@ -57,7 +57,7 @@ function getIdentifierMemoStatus(
   const isFunctionParameter = node.id.name !== name;
   if (node.type === "FunctionDeclaration") return {node: node, status: isFunctionParameter ? MemoStatus.Memoized : MemoStatus.UnmemoizedFunction};
   if (node.type !== "VariableDeclarator") return {node: node, status: MemoStatus.Memoized};
-  if (node?.parent?.kind === "let") {
+  if (node?.parent?.kind === "let" && node?.init?.type === 'CallExpression' && getIsHook(node?.init?.callee)) {
     return {node: node.parent, status: MemoStatus.UnsafeLet};
   }
   return getExpressionMemoStatus(context, node.init);


### PR DESCRIPTION

### Fix

-  No longer complains about any variable declared with `let` when returned from a hook or used as a prop, now it'll only complain if you assign a hook call to a `let` var. 
- Mistakenly considering any function parameter as unmemoized when passed to a Component's prop field.