### PR TITLE
fix: import multiple hooks when react is imported

### DIFF
--- a/__tests__/require-usememo.test.ts
+++ b/__tests__/require-usememo.test.ts
@@ -686,6 +686,25 @@ import type { ComponentProps } from 'react';
         errors: [{ messageId: "array-usememo-props" }],
       },
       {
+        code: `import type { ComponentProps } from 'react';
+        import React, { useRef } from 'react';
+
+        const Component = () => {
+          const myRef = useRef();
+          const myArray = [];
+          return <Child ref={myRef} prop={myArray} />;
+        }`,
+        output: `import type { ComponentProps } from 'react';
+        import React, { useRef, useMemo } from 'react';
+
+        const Component = () => {
+          const myRef = useRef();
+          const myArray = useMemo(() => [], []);
+          return <Child ref={myRef} prop={myArray} />;
+        }`,
+        errors: [{ messageId: "array-usememo-props" }],
+      },
+      {
         code: `
         function useTest() {
           return { x: 1 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arthurgeron/eslint-plugin-react-usememo",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "",
   "main": "dist/index.js",
   "author": "Stefano J. Attardi <github@attardi.org> & Arthur Geron <github@arthurgeron.org",

--- a/src/require-usememo/utils.ts
+++ b/src/require-usememo/utils.ts
@@ -62,7 +62,7 @@ function addReactImports(context: Rule.RuleContext, kind: 'useMemo' | 'useCallba
 
       if (!hasCurrentSpecifier) {
         specifiers.push(specifier);
-        const insertPosition = specifiers.find(specifier => !!specifier.range);
+        const insertPosition = specifiers.find(specifier => !!specifier.range && (!hasDefaultExport || specifier.type !== 'ImportDefaultSpecifier'));
 
         if (insertPosition) {
           return fixer.insertTextAfter(insertPosition, `, ${kind}`);


### PR DESCRIPTION
the following code

```js
import React, { useRef } from 'react';

const Component = () => {
  const myRef = useRef();
  const myArray = [];
  return <Child ref={myRef} prop={myArray} />;
}
```

breaks the order of imports when fixed

```js
import React, useMemo, { useRef } from 'react';

const Component = () => {
  const myRef = useRef();
  const myArray = useMemo(() => [], []);
  return <Child ref={myRef} prop={myArray} />;
}
```