### PR TITLE
fix: require usememo rule checking global jsx

### DIFF
--- a/__tests__/require-usememo.test.ts
+++ b/__tests__/require-usememo.test.ts
@@ -88,6 +88,15 @@ describe('Rule - Require-usememo', () =>  {
         }`
       },
       {
+        code: `
+        const labels = ['data']
+      const Content = <Text labels={labels} />
+        const Component = () => {
+          const myArray = useMemo(() => new Object(), []);
+          return <Child prop={myArray} />;
+        }`
+      },
+      {
         code: `function Component() {
         const myArray = useMemo(() => new Object(), []);
         return <Child prop={myArray} />;

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
   "dependencies": {
     "minimatch": "9.0.3",
     "uuid": "9.0.1"
+  },
+  "overrides": {
+    "braces": ">=3.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arthurgeron/eslint-plugin-react-usememo",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "",
   "main": "dist/index.js",
   "author": "Stefano J. Attardi <github@attardi.org> & Arthur Geron <github@arthurgeron.org",

--- a/src/require-usememo-children.ts
+++ b/src/require-usememo-children.ts
@@ -1,6 +1,6 @@
-import { Rule } from "eslint";
-import * as ESTree from "estree";
-import { TSESTree } from "@typescript-eslint/types";
+import type { Rule } from "eslint";
+import type * as ESTree from "estree";
+import type { TSESTree } from "@typescript-eslint/types";
 import {
   getExpressionMemoStatus,
   isComplexComponent,

--- a/src/require-usememo/index.ts
+++ b/src/require-usememo/index.ts
@@ -47,6 +47,11 @@ const rule: Rule.RuleModule  = {
 
     function process(node: NodeType, _expression?: ExpressionTypes, expressionData?: ExpressionData, checkContext = false) {
 
+      const isGlobalScope = context.getScope().block.type === 'Program';
+      if (checkContext && isGlobalScope) {
+        return;
+      }
+
       const expression = _expression ?? (node.value && Object.prototype.hasOwnProperty.call(node.value, 'expression') ? (node.value as unknown as TSESTree.JSXExpressionContainer).expression : node.value ) ;
       switch(expression?.type) {
         case 'LogicalExpression':

--- a/src/require-usememo/index.ts
+++ b/src/require-usememo/index.ts
@@ -32,7 +32,7 @@ const rule: Rule.RuleModule  = {
   },
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     let isClass = false;
-    let importData: ReactImportInformation = {
+    const importData: ReactImportInformation = {
       reactImported: false,
       useMemoImported: false,
       useCallbackImported: false,

--- a/src/require-usememo/index.ts
+++ b/src/require-usememo/index.ts
@@ -1,5 +1,5 @@
-import { Rule } from "eslint";
-import { TSESTree } from "@typescript-eslint/types";
+import type { Rule } from "eslint";
+import type { TSESTree } from "@typescript-eslint/types";
 import { defaultReactHookNames, jsxEmptyExpressionClassData, jsxEmptyExpressionData, callExpressionData, hookReturnExpressionData  } from './constants';
 import { MessagesRequireUseMemo  } from '../constants';
 import {
@@ -9,7 +9,7 @@ import {
 } from "../utils";
 import type {ExpressionTypes, NodeType, ExpressionData, ReactImportInformation, ImportNode} from './types';
 import { checkForErrors, fixBasedOnMessageId, getIsHook } from './utils';
-import { ESNode, MemoStatus } from "src/types";
+import { type ESNode, MemoStatus } from "src/types";
 
 const rule: Rule.RuleModule  = {
   meta: {

--- a/src/require-usememo/types.ts
+++ b/src/require-usememo/types.ts
@@ -1,6 +1,6 @@
-import { Rule } from "eslint";
+import type { Rule } from "eslint";
 import type { TSESTree } from "@typescript-eslint/types";
-import { MessagesRequireUseMemo} from '../constants';
+import type { MessagesRequireUseMemo} from '../constants';
 
 export type ExpressionTypes = TSESTree.ArrowFunctionExpression | TSESTree.JSXExpressionContainer | TSESTree.Expression | TSESTree.ObjectExpression | TSESTree.ArrayExpression | TSESTree.Identifier | TSESTree.LogicalExpression | TSESTree.JSXEmptyExpression;
 

--- a/src/require-usememo/utils.ts
+++ b/src/require-usememo/utils.ts
@@ -1,9 +1,9 @@
-import { Rule } from "eslint";
-import { TSESTree } from "@typescript-eslint/types";
+import type { Rule } from "eslint";
+import type { TSESTree } from "@typescript-eslint/types";
 import type * as ESTree from "estree";
-import { MessagesRequireUseMemo } from '../constants';
+import type { MessagesRequireUseMemo } from '../constants';
 import type {  ExpressionData, ReactImportInformation } from "./types";
-import { MemoStatus, MemoStatusToReport } from "src/types";
+import { MemoStatus, type MemoStatusToReport } from "src/types";
 import { messageIdToHookDict, nameGeneratorUUID, defaultImportRangeStart } from "./constants";
 import getVariableInScope from "src/utils/getVariableInScope";
 import { v5 as uuidV5 } from 'uuid';

--- a/src/require-usememo/utils.ts
+++ b/src/require-usememo/utils.ts
@@ -208,7 +208,7 @@ export function fixBasedOnMessageId(node: Rule.Node, messageId: keyof typeof Mes
     case 'object-usememo-props':
     case 'jsx-usememo-props':
     case 'usememo-const': {
-      let variableDeclaration = node.type === 'VariableDeclaration' ? node : findParentType(node as Rule.Node, 'VariableDeclaration') as TSESTree.VariableDeclaration;
+      const variableDeclaration = node.type === 'VariableDeclaration' ? node : findParentType(node as Rule.Node, 'VariableDeclaration') as TSESTree.VariableDeclaration;
 
       // Check if it is a hook being stored in let/var, change to const if so
       if (variableDeclaration && variableDeclaration.kind !== 'const') {
@@ -260,10 +260,10 @@ export function fixBasedOnMessageId(node: Rule.Node, messageId: keyof typeof Mes
   }
 
   // Simpler cases bellow, all of them are just adding useMemo/Callback
-  let functionPrefix = isArrowFunctionExpression ? '' : '() => ';
-  let expressionPrefix = isObjExpression || isJSXElement ? '(' : '';
-  let coreExpression = sourceCode.getText(node as unknown as ESTree.Node);
-  let expressionSuffix = isObjExpression ? ')' : '';
+  const functionPrefix = isArrowFunctionExpression ? '' : '() => ';
+  const expressionPrefix = isObjExpression || isJSXElement ? '(' : '';
+  const coreExpression = sourceCode.getText(node as unknown as ESTree.Node);
+  const expressionSuffix = isObjExpression ? ')' : '';
 
   let fixed = `${hook}(${functionPrefix}${expressionPrefix}${coreExpression}${expressionSuffix}, [])`;
   const importStatementFixes = addReactImports(context, hook, reactImportData, fixer);

--- a/src/require-usememo/utils.ts
+++ b/src/require-usememo/utils.ts
@@ -117,16 +117,18 @@ export function getIsHook(node: TSESTree.Node | TSESTree.Identifier) {
   if (node.type === "Identifier") {
     const { name } = node;
     return name === 'use' || ((name?.length ?? 0) >= 4 && name[0] === 'u' && name[1] === 's' && name[2] === 'e' && name[3] === name[3]?.toUpperCase?.());
-  } else if (
+  } 
+  
+  if (
     node.type === "MemberExpression" &&
     !node.computed &&
     getIsHook(node.property)
   ) {
     const { object: obj } = node; // Utilizing Object destructuring
     return obj.type === "Identifier" && obj.name === "React";
-  } else {
-    return false;
   }
+
+  return false;
 }
 
 // Helper function to find parent of a specified type. 
@@ -173,7 +175,7 @@ function getSafeVariableName(context: Rule.RuleContext, name: string, attempts =
 // Eslint Auto-fix logic, functional components/hooks only
 export function fixBasedOnMessageId(node: Rule.Node, messageId: keyof typeof MessagesRequireUseMemo, fixer: Rule.RuleFixer, context: Rule.RuleContext, reactImportData: ReactImportInformation) {
   const sourceCode = context.getSourceCode();
-  let hook = messageIdToHookDict[messageId] || 'useMemo';
+  const hook = messageIdToHookDict[messageId] || 'useMemo';
   const isObjExpression = node.type === 'ObjectExpression';
   const isJSXElement = (node as unknown as TSESTree.JSXElement).type === 'JSXElement';
   const parentIsVariableDeclarator = (node as Rule.Node).parent.type === 'VariableDeclarator';

--- a/src/require-usememo/utils.ts
+++ b/src/require-usememo/utils.ts
@@ -195,7 +195,7 @@ export function fixBasedOnMessageId(node: Rule.Node, messageId: keyof typeof Mes
         return fixes;
       }
       break;
-    case 'object-usememo-hook':
+    case 'object-usememo-hook': {
       const _returnNode = node as TSESTree.ReturnStatement;
       // An undefined node.argument means returned value is not an expression, but most probably a variable which should not be handled here, which falls under default, simpler fix logic.
       if(_returnNode.argument) {
@@ -206,6 +206,7 @@ export function fixBasedOnMessageId(node: Rule.Node, messageId: keyof typeof Mes
         return fixes;
       } 
       break;
+    }
     case 'function-usecallback-props':
     case 'object-usememo-props':
     case 'jsx-usememo-props':

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-import { Rule } from "eslint";
-import { TSESTree } from "@typescript-eslint/types";
+import type { Rule } from "eslint";
+import type { TSESTree } from "@typescript-eslint/types";
 
 export type MemoStatusToReport = {
   node?: Rule.RuleContext | TSESTree.Node,

--- a/src/utils/getVariableInScope.ts
+++ b/src/utils/getVariableInScope.ts
@@ -1,4 +1,4 @@
-import { Rule } from "eslint";
+import type { Rule } from "eslint";
 
 export default function getVariableInScope(context: Rule.RuleContext, name: string) {
   return context.getScope().variables.find((variable) => variable.name === name);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -143,7 +143,7 @@ export function shouldIgnoreNode(node: ESNode, ignoredNames: Record<string, bool
     }
 
     // Checking via patterns
-    let shouldIgnore;
+    let shouldIgnore: boolean | undefined;
     
     Object.keys(ignoredNames).find(key => {
       const value = ignoredNames[key];

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
-import { Rule, Scope } from "eslint";
-import { TSESTree } from "@typescript-eslint/types";
-import * as ESTree from "estree";
-import { ESNode, MemoStatus, MemoStatusToReport } from "src/types";
+import type { Rule, Scope } from "eslint";
+import type { TSESTree } from "@typescript-eslint/types";
+import type * as ESTree from "estree";
+import { type ESNode, MemoStatus, type MemoStatusToReport } from "src/types";
 import { getIsHook, isImpossibleToFix } from "src/require-usememo/utils";
 import getVariableInScope from "src/utils/getVariableInScope";
 import {Minimatch} from 'minimatch'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,12 +1255,12 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
-  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+braces@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
-    fill-range "^7.0.1"
+    fill-range "^7.1.1"
 
 browserslist@^4.21.9:
   version "4.22.1"
@@ -1814,10 +1814,10 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
-fill-range@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
-  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
 


### PR DESCRIPTION
Closes #45 

- Fixes global variables storing JSX being wrongfully checked as if they were in component scope
- Other minor code cleanups
- Updated `braces` package to avoid high risk vulnerability