### PR TITLE
fix: append `async` keyword when replace async func with useCallback

### DIFF
--- a/__tests__/require-usecallback.test.ts
+++ b/__tests__/require-usecallback.test.ts
@@ -287,6 +287,13 @@ describe('Rule - Require-usecallback', () =>  {
         }`,
         errors: [{ messageId: "function-usecallback-props" }],
       },
+      {
+        code: `
+        const Component = () => {
+          return <Child prop={async () => []} />;
+        }`,
+        errors: [{ messageId: "function-usecallback-props" }],
+      },
     ],
   });
 });

--- a/__tests__/require-usecallback.test.ts
+++ b/__tests__/require-usecallback.test.ts
@@ -259,6 +259,34 @@ describe('Rule - Require-usecallback', () =>  {
         }`,
         errors: [{ messageId: "function-usecallback-props" }, { messageId: "function-usecallback-props" }],
       },
+      {
+        code: `
+        const Component = () => {
+          const myFn = async function test() {};
+          return <Child prop={myFn} />;
+        }`,
+        output: `import { useCallback } from 'react';
+
+        const Component = () => {
+          const myFn = useCallback(async () => {}, []);
+          return <Child prop={myFn} />;
+        }`,
+        errors: [{ messageId: "function-usecallback-props" }],
+      },
+      {
+        code: `
+        const Component = () => {
+          const myFn = async () => [];
+          return <Child prop={myFn} />;
+        }`,
+        output: `import { useCallback } from 'react';
+
+        const Component = () => {
+          const myFn = useCallback(async () => [], []);
+          return <Child prop={myFn} />;
+        }`,
+        errors: [{ messageId: "function-usecallback-props" }],
+      },
     ],
   });
 });

--- a/__tests__/require-usecallback.test.ts
+++ b/__tests__/require-usecallback.test.ts
@@ -153,16 +153,30 @@ describe('Rule - Require-usecallback', () =>  {
         errors: [{ messageId: "usememo-const" }],
       },
       {
-        code: `const Component = () => {
+        code: `
+        const Component = () => {
           return <Child prop={() => {}} />;
         }`,
         errors: [{ messageId: "function-usecallback-props" }],
+        output: `import { useCallback } from 'react';
+
+        const Component = () => {
+          const prop = useCallback(() => {}, []);
+          return <Child prop={prop} />;
+        }`,
       },
       {
-        code: `const Component = () => {
+        code: `
+        const Component = () => {
           return <Child prop={() => []} />;
         }`,
         errors: [{ messageId: "function-usecallback-props" }],
+        output: `import { useCallback } from 'react';
+
+        const Component = () => {
+          const prop = useCallback(() => [], []);
+          return <Child prop={prop} />;
+        }`,
       },
       {
         code: `class Component {
@@ -291,6 +305,12 @@ describe('Rule - Require-usecallback', () =>  {
         code: `
         const Component = () => {
           return <Child prop={async () => []} />;
+        }`,
+         output: `import { useCallback } from 'react';
+
+        const Component = () => {
+          const prop = useCallback(async () => [], []);
+          return <Child prop={prop} />;
         }`,
         errors: [{ messageId: "function-usecallback-props" }],
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arthurgeron/eslint-plugin-react-usememo",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "",
   "main": "dist/index.js",
   "author": "Stefano J. Attardi <github@attardi.org> & Arthur Geron <github@arthurgeron.org",

--- a/src/require-usememo/utils.ts
+++ b/src/require-usememo/utils.ts
@@ -150,7 +150,7 @@ function fixFunction(node: TSESTree.FunctionDeclaration | TSESTree.FunctionExpre
   const { body, params = [] } = node;
   const funcBody = sourceCode.getText(body as ESTree.Node);
   const funcParams = (params as Array<ESTree.Node>).map(node => sourceCode.getText(node));
-  let fixedCode = `useCallback((${funcParams.join(', ')}) => ${funcBody}, [])${shouldSetName ? ';' : ''}`
+  let fixedCode = `useCallback(${node.async ? 'async ' : ''}(${funcParams.join(', ')}) => ${funcBody}, [])${shouldSetName ? ';' : ''}`
   if (shouldSetName && node?.id?.name) {
     const name = node?.id?.name;
     fixedCode = `const ${name} = ${fixedCode}`;

--- a/src/require-usememo/utils.ts
+++ b/src/require-usememo/utils.ts
@@ -178,10 +178,9 @@ export function fixBasedOnMessageId(node: Rule.Node, messageId: keyof typeof Mes
   const hook = messageIdToHookDict[messageId] || 'useMemo';
   const isObjExpression = node.type === 'ObjectExpression';
   const isJSXElement = (node as unknown as TSESTree.JSXElement).type === 'JSXElement';
-  const parentIsVariableDeclarator = (node as Rule.Node).parent.type === 'VariableDeclarator';
   const isArrowFunctionExpression = node.type === 'ArrowFunctionExpression';
   const isFunctionExpression = node.type === 'FunctionExpression';
-  const isCorrectableFunctionExpression = isFunctionExpression || (isArrowFunctionExpression && parentIsVariableDeclarator);
+  const isCorrectableFunctionExpression = isFunctionExpression || isArrowFunctionExpression;
   const fixes: Array<Rule.Fix> = [];
 
   // Determine what type of behavior to follow according to the error message


### PR DESCRIPTION
## Description
<!-- Please provide a clear and concise description of the changes and the purpose they serve. -->

the following code

```jsx
const Component = () => {
  const myFn = async () => [];
  return <Child prop={myFn} />;
}
```

disappear `async` keyword when fixed

```jsx
import { useCallback } from 'react';

const Component = () => {
  const myFn = useCallback(() => [], []);
  return <Child prop={myFn} />;
}
```

## Checklist
<!--Before submitting your pull request, please confirm the following: -->

- [x] **Tests**: I have created multiple test case scenarios for my changes.
- [x] **Passing Tests**: All existing and new tests are passing.
- [x] **Version Bump**: I have increased the package version number in `package.json` following the [Semantic Versioning](https://semver.org/) (SEMVER) standard.
- [x] **Focused Changes**: My code changes are focused solely on the matter described above.

## Additional Information
<!-- If applicable, please provide any additional information or context for your changes. -->

n/a