### PR TITLE
fix: replace underscore with number words for variable names

### DIFF
--- a/__tests__/require-usememo.test.ts
+++ b/__tests__/require-usememo.test.ts
@@ -569,8 +569,8 @@ describe('Rule - Require-usememo', () =>  {
 
         const Component = () => {
           const userData = undefined;
-          const _userData = useMemo(() => ({}), []);
-          return <Child userData={_userData} />;
+          const userDataOne = useMemo(() => ({}), []);
+          return <Child userData={userDataOne} />;
         }`,
         errors: [{ messageId: "object-usememo-props" }],
       },
@@ -584,8 +584,8 @@ describe('Rule - Require-usememo', () =>  {
 
         const Component = () => {
           const userData = undefined;
-          const _userData = useMemo(() => ({}), []);
-          return <Child userData={_userData} />;
+          const userDataOne = useMemo(() => ({}), []);
+          return <Child userData={userDataOne} />;
         }`,
         errors: [{ messageId: "object-usememo-props" }],
       },
@@ -593,16 +593,16 @@ describe('Rule - Require-usememo', () =>  {
         code: `
         const Component = () => {
           const userData = undefined;
-          const _userData = undefined;
+          const userDataOne = undefined;
           return <Child userData={{}} />;
         }`,
         output: `import { useMemo } from 'react';
 
         const Component = () => {
           const userData = undefined;
-          const _userData = undefined;
-          const __userData = useMemo(() => ({}), []);
-          return <Child userData={__userData} />;
+          const userDataOne = undefined;
+          const userDataOneTwo = useMemo(() => ({}), []);
+          return <Child userData={userDataOneTwo} />;
         }`,
         errors: [{ messageId: "object-usememo-props" }],
       },
@@ -610,24 +610,24 @@ describe('Rule - Require-usememo', () =>  {
         code: `
         const Component = () => {
           const userData = undefined;
-          const _userData = undefined;
-          const __userData = undefined;
-          const ___userData = undefined;
-          const ____userData = undefined;
-          const _____userData = undefined;
+          const userDataOne = undefined;
+          const userDataTwo = undefined;
+          const userDataThree = undefined;
+          const userDataFour = undefined;
+          const userDataFive = undefined;
           return <Child userData={{}} />;
         }`,
         output: `import { useMemo } from 'react';
 
         const Component = () => {
           const userData = undefined;
-          const _userData = undefined;
-          const __userData = undefined;
-          const ___userData = undefined;
-          const ____userData = undefined;
-          const _____userData = undefined;
-          const renameMe = useMemo(() => ({}), []);
-          return <Child userData={renameMe} />;
+          const userDataOne = undefined;
+          const userDataTwo = undefined;
+          const userDataThree = undefined;
+          const userDataFour = undefined;
+          const userDataFive = undefined;
+          const userDataOneTwo = useMemo(() => ({}), []);
+          return <Child userData={userDataOneTwo} />;
         }`,
         errors: [{ messageId: "object-usememo-props" }],
       },
@@ -635,11 +635,11 @@ describe('Rule - Require-usememo', () =>  {
         code: `
         const Component = () => {
           const userData = undefined;
-          const _userData = undefined;
-          const __userData = undefined;
-          const ___userData = undefined;
-          const ____userData = undefined;
-          const _____userData = undefined;
+          const userDataOne = undefined;
+          const userDataTwo = undefined;
+          const userDataThree = undefined;
+          const userDataFour = undefined;
+          const userDataFive = undefined;
           const renameMe = undefined;
           return <Child userData={{}} />;
         }`,
@@ -647,14 +647,14 @@ describe('Rule - Require-usememo', () =>  {
 
         const Component = () => {
           const userData = undefined;
-          const _userData = undefined;
-          const __userData = undefined;
-          const ___userData = undefined;
-          const ____userData = undefined;
-          const _____userData = undefined;
+          const userDataOne = undefined;
+          const userDataTwo = undefined;
+          const userDataThree = undefined;
+          const userDataFour = undefined;
+          const userDataFive = undefined;
           const renameMe = undefined;
-          const renameMe_99c32a94 = useMemo(() => ({}), []);
-          return <Child userData={renameMe_99c32a94} />;
+          const userDataOneTwo = useMemo(() => ({}), []);
+          return <Child userData={userDataOneTwo} />;
         }`,
         errors: [{ messageId: "object-usememo-props" }],
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arthurgeron/eslint-plugin-react-usememo",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "",
   "main": "dist/index.js",
   "author": "Stefano J. Attardi <github@attardi.org> & Arthur Geron <github@arthurgeron.org",

--- a/src/require-usememo/utils.ts
+++ b/src/require-usememo/utils.ts
@@ -158,6 +158,31 @@ function fixFunction(node: TSESTree.FunctionDeclaration | TSESTree.FunctionExpre
   return fixedCode;
 }
 
+const single_digit = ['', 'One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight', 'Nine'];
+const double_digit = ['Ten', 'Eleven', 'Twelve', 'Thirteen', 'Fourteen', 'Fifteen', 'Sixteen', 'Seventeen', 'Eighteen', 'Nineteen'];
+const below_hundred = ['Twenty', 'Thirty', 'Forty', 'Fifty', 'Sixty', 'Seventy', 'Eighty', 'Ninety'];
+
+function numberToWord(n: number): string {
+  let word = "";
+  if (n < 10) {
+      word = single_digit[n];
+  } else if (n < 20) {
+      word = double_digit[n - 10];
+  } else if (n < 100) {
+      let rem = numberToWord(n % 10);
+      word = below_hundred[(n - n % 10) / 10 - 2] + rem;
+  } else if (n < 1000) {
+      word = single_digit[Math.trunc(n / 100)] + 'Hundred' + numberToWord(n % 100);
+  } else if (n < 1000000) {
+      word = numberToWord(parseInt(n / 1000 + "")).trim() + 'Thousand' + numberToWord(n % 1000);
+  } else if (n < 1000000000) {
+      word = numberToWord(parseInt(n / 1000000 + "")).trim() + 'Million' + numberToWord(n % 1000000);
+  } else {
+      word = numberToWord(parseInt(n / 1000000000 + "")).trim() + 'Billion' + numberToWord(n % 1000000000);
+  }
+  return word;
+}
+
 function getSafeVariableName(context: Rule.RuleContext, name: string, attempts = 0): string {
   const tempVarPlaceholder = 'renameMe';
 
@@ -166,9 +191,10 @@ function getSafeVariableName(context: Rule.RuleContext, name: string, attempts =
   }
   if (attempts >= 5) {
     const nameExtensionIfExists = getVariableInScope(context, tempVarPlaceholder) ? uuidV5(name, nameGeneratorUUID).split('-')[0] : '';
-    return `${tempVarPlaceholder}${nameExtensionIfExists ? `_${nameExtensionIfExists}` : ''}`;
+    return `${tempVarPlaceholder}${nameExtensionIfExists ? `${nameExtensionIfExists}${numberToWord(attempts)}` : ''}`;
   }
-  return getSafeVariableName(context, `_${name}`, ++attempts);
+  ++attempts;
+  return getSafeVariableName(context, `${name}${numberToWord(attempts)}`, attempts);
 
 }
 


### PR DESCRIPTION
# Pull Request Template

## Description
When finding safe variable name for hook generate numbered words suffixes instead of underscore character to avoid duplicates, e.g.

variableOne

instead of 

_variable

## Checklist

- [x] **Tests**: I have created multiple test case scenarios for my changes.
- [x] **Passing Tests**: All existing and new tests are passing.
- [x] **Version Bump**: I have increased the package version number in `package.json` following the [Semantic Versioning](https://semver.org/) (SEMVER) standard.
- [x] **Focused Changes**: My code changes are focused solely on the matter described above.

## Additional Information
<!-- If applicable, please provide any additional information or context for your changes. -->
